### PR TITLE
[US-04] Add seasons to details

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -40,7 +40,7 @@ export default function App() {
       <Route exact path={['/', '/watchlist']}>
         <Header />
       </Route>
-      <main>
+      <StyledMain>
         <Switch>
           <Route exact path="/">
             <PosterList list={series.filter(el => el.isPopular)} />
@@ -70,7 +70,7 @@ export default function App() {
           </Route>
           <Route>404 not found</Route>
         </Switch>
-      </main>
+      </StyledMain>
     </Container>
   )
 
@@ -97,6 +97,10 @@ const Container = styled.div`
   max-width: 1024px;
   width: 100%;
   margin-bottom: 32px;
+`
+
+const StyledMain = styled.main`
+  width: 100%;
 `
 
 const StyledParagraph = styled.p`

--- a/client/src/components/ButtonSeason.js
+++ b/client/src/components/ButtonSeason.js
@@ -17,7 +17,6 @@ export default function ButtonSeason({ name, onClick, isActive }) {
 const StyledButton = styled.button`
   border: 2px solid #38b4f2;
   padding: 4px;
-  /* margin: 8px 0 0 0; */
   text-decoration: none;
   background-color: ${props => (props.isActive ? '#38b4f2' : '#14171a')};
   color: ${props => (props.isActive ? '#14171a' : '#fff')};

--- a/client/src/components/ButtonSeason.js
+++ b/client/src/components/ButtonSeason.js
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types'
+import styled from 'styled-components/macro'
+
+ButtonSeason.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  isActive: PropTypes.bool.isRequired,
+}
+
+export default function ButtonSeason({ name, onClick, isActive }) {
+  return (
+    <StyledButton onClick={onClick} isActive={isActive}>
+      {name}
+    </StyledButton>
+  )
+}
+
+const StyledButton = styled.button`
+  border: 2px solid #38b4f2;
+  padding: 4px;
+  /* margin: 8px 0 0 0; */
+  text-decoration: none;
+  background-color: ${props => (props.isActive ? '#38b4f2' : '#14171a')};
+  color: ${props => (props.isActive ? '#14171a' : '#fff')};
+  font-family: inherit;
+  font-size: 0.75rem;
+  letter-spacing: 1px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+  text-transform: uppercase;
+  white-space: nowrap;
+`

--- a/client/src/components/ButtonSeason.spec.js
+++ b/client/src/components/ButtonSeason.spec.js
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ButtonSeason from './ButtonSeason'
+
+describe('ButtonWatchlist', () => {
+  it('renders', () => {
+    render(<ButtonSeason onClick={() => jest.fn()} isActive={true} />)
+
+    const button = screen.getByRole('button')
+    expect(button).toBeInTheDocument()
+  })
+
+  it('has onClick function', () => {
+    const handleOnClick = jest.fn()
+    render(<ButtonSeason onClick={handleOnClick} isActive={true} />)
+
+    const button = screen.getByRole('button')
+    userEvent.click(button)
+    expect(handleOnClick).toHaveBeenCalled()
+  })
+
+  it('has the correct button text', () => {
+    render(
+      <ButtonSeason
+        onClick={() => jest.fn()}
+        isActive={true}
+        name={'Staffel 1'}
+      />
+    )
+
+    const text = screen.getByText('Staffel 1')
+    expect(text).toBeInTheDocument()
+  })
+})

--- a/client/src/components/ButtonSeason.stories.js
+++ b/client/src/components/ButtonSeason.stories.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import ButtonSeason from './ButtonSeason'
+
+export default {
+  title: 'ButtonSeason',
+  component: ButtonSeason,
+}
+
+const Template = args => <ButtonSeason {...args} />
+
+export const Active = Template.bind({})
+Active.args = { name: 'Staffel 1', isActive: true }
+
+export const Inactive = Template.bind({})
+Inactive.args = { name: 'Staffel 1', isActive: false }

--- a/client/src/components/EpisodeCard.js
+++ b/client/src/components/EpisodeCard.js
@@ -1,0 +1,56 @@
+import PropTypes from 'prop-types'
+import styled from 'styled-components/macro'
+
+EpisodeCard.propTypes = {
+  episode: PropTypes.object.isRequired,
+}
+
+export default function EpisodeCard({ episode }) {
+  const { name, episode_number: episodeNumber, overview } = episode
+  return (
+    <Wrapper>
+      <Heading>
+        <span>{episodeNumber}</span>
+        <h4>{name}</h4>
+      </Heading>
+      <p>{overview}</p>
+    </Wrapper>
+  )
+}
+
+const Wrapper = styled.li`
+  display: flex;
+  flex-direction: column;
+  padding: 8px;
+  border-radius: 4px;
+  background: #3c4b5b;
+  margin-bottom: 16px;
+  position: relative;
+
+  p {
+    margin: 0;
+  }
+`
+
+const Heading = styled.div`
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 1.1rem;
+  margin-bottom: 4px;
+
+  span {
+    font-size: 1rem;
+    font-weight: bold;
+    color: #14171a;
+    width: calc(2ch + 16px);
+    text-align: center;
+    background-color: #38b4f2;
+    padding: 4px 8px;
+    border-radius: 4px;
+  }
+
+  h4 {
+    margin: 0;
+  }
+`

--- a/client/src/components/EpisodeCard.spec.js
+++ b/client/src/components/EpisodeCard.spec.js
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import EpisodeCard from './EpisodeCard'
+
+describe('EpisodeCard', () => {
+  it('renders', () => {
+    const episode = {
+      name: 'Title',
+      overview: 'Lorem Ipsum Dolor',
+      episode_number: 1,
+    }
+
+    render(<EpisodeCard episode={episode} />)
+
+    const element = screen.getByRole('listitem')
+    expect(element).toBeInTheDocument()
+  })
+
+  it('has a heading', () => {
+    const episode = {
+      name: 'Title',
+      overview: 'Lorem Ipsum Dolor',
+      episode_number: 1,
+    }
+
+    render(<EpisodeCard episode={episode} />)
+
+    const headline = screen.getByRole('heading')
+    expect(headline).toBeInTheDocument()
+  })
+
+  it('has the correct heading text', () => {
+    const episode = {
+      name: 'Title',
+      overview: 'Lorem Ipsum Dolor',
+      episode_number: 1,
+    }
+
+    render(<EpisodeCard episode={episode} />)
+
+    const text = screen.getByText('Title')
+    expect(text).toBeInTheDocument()
+  })
+})

--- a/client/src/components/EpisodeCard.stories.js
+++ b/client/src/components/EpisodeCard.stories.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import EpisodeCard from './EpisodeCard'
+
+export default {
+  title: 'EpisodeCard',
+  component: EpisodeCard,
+}
+
+const Template = args => <EpisodeCard {...args} />
+
+export const Default = Template.bind({})
+Default.args = {
+  episode: {
+    name: 'Title',
+    overview:
+      'Lorem ipsum dolor sit, amet consectetur adipisicing elit. Fugiat dignissimos dolorum nulla id officiis voluptatibus sed assumenda nihil sit aliquam.',
+    episode_number: 1,
+  },
+}

--- a/client/src/components/SeasonsList.js
+++ b/client/src/components/SeasonsList.js
@@ -1,0 +1,126 @@
+import PropTypes from 'prop-types'
+import { useEffect, useState } from 'react'
+import styled from 'styled-components/macro'
+import ButtonSeason from './ButtonSeason'
+import EpisodeCard from './EpisodeCard'
+import Poster from './Poster'
+
+SeasonsList.propTypes = {
+  seriesSeasons: PropTypes.array.isRequired,
+}
+
+export default function SeasonsList({ seriesSeasons }) {
+  const [seasons, setSeasons] = useState(null)
+  const [currentSeasonNumber, setCurrentSeasonNumber] = useState(1)
+  const [currentSeason, setCurrentSeason] = useState(null)
+  const [currentEpisodes, setCurrentEpisodes] = useState(null)
+
+  useEffect(() => {
+    if (seriesSeasons.length > 0) {
+      setSeasons(seriesSeasons)
+    }
+  }, [seriesSeasons])
+
+  useEffect(() => {
+    if (seasons) {
+      const filteredSeason = seasons.find(
+        ({ season_number: seasonNumber }) =>
+          seasonNumber === currentSeasonNumber
+      )
+      setCurrentSeason(filteredSeason)
+    }
+  }, [seasons, currentSeasonNumber])
+
+  useEffect(() => {
+    if (currentSeason) {
+      const episodes = currentSeason.episodes
+      setCurrentEpisodes(episodes)
+    }
+  }, [currentSeason])
+
+  return (
+    <Wrapper>
+      <Navigation>
+        {seriesSeasons.map(({ season_number: seasonNumber, name }) => (
+          <ButtonSeason
+            key={seasonNumber}
+            name={name}
+            onClick={() => handleOnClick(seasonNumber)}
+            isActive={Number(seasonNumber) === Number(currentSeasonNumber)}
+          />
+        ))}
+      </Navigation>
+      {currentSeason && (
+        <SeasonMeta>
+          <Poster
+            path={
+              currentSeason.poster_path !== undefined &&
+              currentSeason.poster_path
+                ? `https://image.tmdb.org/t/p/w300${currentSeason.poster_path}`
+                : '../poster.png'
+            }
+            alt={`Poster von ${currentSeason.name}`}
+          />
+          {
+            <SeasonMetaInfo>
+              <h3>{currentSeason.name}</h3>
+              <div>
+                <i>Ausstrahlung:</i>{' '}
+                <strong>{formatDate(currentSeason.air_date)}</strong>
+              </div>
+              <div>
+                <i>Episoden:</i>{' '}
+                <strong>{currentSeason.episodes.length}</strong>
+              </div>
+            </SeasonMetaInfo>
+          }
+        </SeasonMeta>
+      )}
+      <StyledList>
+        {currentEpisodes &&
+          currentEpisodes.map(episode => (
+            <EpisodeCard key={episode.id} episode={episode} />
+          ))}
+      </StyledList>
+    </Wrapper>
+  )
+
+  function handleOnClick(seasonNumber) {
+    setCurrentSeasonNumber(seasonNumber)
+  }
+
+  function formatDate(date) {
+    return date.split('-').reverse().join('.')
+  }
+}
+
+const Wrapper = styled.div``
+
+const Navigation = styled.nav`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 16px;
+`
+
+const SeasonMeta = styled.div`
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+
+  h3 {
+    margin-top: 0;
+  }
+`
+
+const SeasonMetaInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+const StyledList = styled.ul`
+  padding: 0;
+  list-style-type: none;
+`

--- a/client/src/components/SeasonsList.js
+++ b/client/src/components/SeasonsList.js
@@ -1,42 +1,21 @@
 import PropTypes from 'prop-types'
-import { useEffect, useState } from 'react'
 import styled from 'styled-components/macro'
 import ButtonSeason from './ButtonSeason'
 import EpisodeCard from './EpisodeCard'
 import Poster from './Poster'
+import useSeasons from '../hooks/useSeasons'
 
 SeasonsList.propTypes = {
   seriesSeasons: PropTypes.array.isRequired,
 }
 
 export default function SeasonsList({ seriesSeasons }) {
-  const [seasons, setSeasons] = useState(null)
-  const [currentSeasonNumber, setCurrentSeasonNumber] = useState(1)
-  const [currentSeason, setCurrentSeason] = useState(null)
-  const [currentEpisodes, setCurrentEpisodes] = useState(null)
-
-  useEffect(() => {
-    if (seriesSeasons.length > 0) {
-      setSeasons(seriesSeasons)
-    }
-  }, [seriesSeasons])
-
-  useEffect(() => {
-    if (seasons) {
-      const filteredSeason = seasons.find(
-        ({ season_number: seasonNumber }) =>
-          seasonNumber === currentSeasonNumber
-      )
-      setCurrentSeason(filteredSeason)
-    }
-  }, [seasons, currentSeasonNumber])
-
-  useEffect(() => {
-    if (currentSeason) {
-      const episodes = currentSeason.episodes
-      setCurrentEpisodes(episodes)
-    }
-  }, [currentSeason])
+  const {
+    currentSeason,
+    currentSeasonNumber,
+    currentEpisodes,
+    setCurrentSeasonNumber,
+  } = useSeasons(seriesSeasons)
 
   return (
     <Wrapper>
@@ -46,7 +25,7 @@ export default function SeasonsList({ seriesSeasons }) {
             key={seasonNumber}
             name={name}
             onClick={() => handleOnClick(seasonNumber)}
-            isActive={Number(seasonNumber) === Number(currentSeasonNumber)}
+            isActive={seasonNumber === currentSeasonNumber}
           />
         ))}
       </Navigation>

--- a/client/src/hooks/useSeasons.js
+++ b/client/src/hooks/useSeasons.js
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+
+export default function useSeasons(seriesSeasons) {
+  const [seasons, setSeasons] = useState(null)
+  const [currentSeasonNumber, setCurrentSeasonNumber] = useState(1)
+  const [currentSeason, setCurrentSeason] = useState(null)
+  const [currentEpisodes, setCurrentEpisodes] = useState(null)
+
+  useEffect(() => {
+    if (seriesSeasons.length > 0) {
+      setSeasons(seriesSeasons)
+    }
+  }, [seriesSeasons])
+
+  useEffect(() => {
+    if (seasons) {
+      const filteredSeason = seasons.find(
+        ({ season_number: seasonNumber }) =>
+          seasonNumber === currentSeasonNumber
+      )
+      setCurrentSeason(filteredSeason)
+    }
+  }, [seasons, currentSeasonNumber])
+
+  useEffect(() => {
+    if (currentSeason) {
+      const episodes = currentSeason.episodes
+      setCurrentEpisodes(episodes)
+    }
+  }, [currentSeason])
+
+  return {
+    currentSeason,
+    currentSeasonNumber,
+    currentEpisodes,
+    setCurrentSeasonNumber,
+  }
+}

--- a/client/src/pages/SeriesDetailsPage.js
+++ b/client/src/pages/SeriesDetailsPage.js
@@ -5,6 +5,7 @@ import styled from 'styled-components/macro'
 import { ReactComponent as IconArrowLeft } from '../assets/icons/long-arrow-alt-left-solid.svg'
 import ButtonWatchlist from '../components/ButtonWatchlist'
 import Poster from '../components/Poster'
+import SeasonsList from '../components/SeasonsList'
 import getSeason from '../services/getSeason'
 import getSeriesCredits from '../services/getSeriesCredits'
 import getSeriesDetails from '../services/getSeriesDetails'
@@ -105,22 +106,7 @@ export default function SeriesDetails({
         )}
       </Overview>
       <h2>Staffeln</h2>
-      <ul>
-        {seriesSeasons.map(({ id, name, episodes }) => (
-          <span key={id}>
-            <li>{name}</li>
-            <ul>
-              {episodes.map(({ id, name, overview }) => (
-                <li key={id}>
-                  {name}
-                  <br />
-                  {overview}
-                </li>
-              ))}
-            </ul>
-          </span>
-        ))}
-      </ul>
+      <SeasonsList seriesSeasons={seriesSeasons} />
       <h2>Besetzung</h2>
       <List>
         {cast.map(({ id, profile_path: profilePath, name, character }) => (

--- a/client/src/pages/SeriesDetailsPage.spec.js
+++ b/client/src/pages/SeriesDetailsPage.spec.js
@@ -13,7 +13,7 @@ describe('SeriesDetailsPage', () => {
     )
 
     const heading = screen.getAllByRole('heading')
-    expect(heading).toHaveLength(2)
+    expect(heading).toHaveLength(3)
   })
 
   it('has a header', () => {
@@ -27,14 +27,14 @@ describe('SeriesDetailsPage', () => {
     expect(header).toBeInTheDocument()
   })
 
-  it('has a list', () => {
+  it('has lists', () => {
     render(
       <Router>
         <SeriesDetailsPage series={series} />
       </Router>
     )
 
-    const list = screen.getByRole('list')
-    expect(list).toBeInTheDocument()
+    const list = screen.getAllByRole('list')
+    expect(list).toHaveLength(2)
   })
 })

--- a/client/src/services/getSeason.js
+++ b/client/src/services/getSeason.js
@@ -1,0 +1,5 @@
+export default function getSeason(id, seasonNumber) {
+  return fetch(`/api/series/${id}/season/${seasonNumber}`).then(res =>
+    res.json()
+  )
+}


### PR DESCRIPTION
Hey 👋 
this is a PR for my next user story.

**App:** https://serientracker.herokuapp.com/
(optimized for mobile)

**New:** it's possible to

- see a list of seasons on the details page
- switch between seasons
- see a list of episodes for each season

In a future PR I want to create **custom hooks** to make to the code more clean and readable.
I will also optimize the episode cards in the future to avoid too long boxes.